### PR TITLE
Add planned walks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ![](https://img.shields.io/badge/version-0.7-blue)
 
-A Discord bot for reporting [DClone Tracker](https://diablo2.io/dclonetracker.php) progress changes and upcoming planned walks for Diablo 2: Resurrected. By default it will report any progress changes at or above level 2 for All Regions, Ladder and Non-Ladder, Softcore and planned walks an hour before they start.
+A Discord bot for reporting [DClone Tracker](https://diablo2.io/dclonetracker.php) progress changes and upcoming [planned walks](https://d2runewizard.com/diablo-clone-tracker#planned-walks) for Diablo 2: Resurrected. By default it will report any progress changes at or above level 2 for All Regions, Ladder and Non-Ladder, Softcore and planned walks an hour before they start.
 
-You can also get the current progress for tracked regions and upcoming walk information by typing `.dclone` or `!dclone` in chat.
+You can also get the current progress for tracked regions and planned walks by typing `.dclone` or `!dclone` in chat.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dclone-discord
 
-![](https://img.shields.io/badge/version-0.6-blue)
+![](https://img.shields.io/badge/version-0.7-blue)
 
 A Discord bot for reporting [DClone Tracker](https://diablo2.io/dclonetracker.php) progress changes and upcoming planned walks for Diablo 2: Resurrected. By default it will report any progress changes at or above level 2 for All Regions, Ladder and Non-Ladder, Softcore and planned walks an hour before they start.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # dclone-discord
 
-![](https://img.shields.io/badge/version-0.5-blue)
+![](https://img.shields.io/badge/version-0.6-blue)
 
-A Discord bot for reporting [DClone Tracker](https://diablo2.io/dclonetracker.php) progress changes for Diablo 2: Resurrected. By default it will report any progress changes at or above level 2 for All Regions, Ladder and Non-Ladder, Softcore.
+A Discord bot for reporting [DClone Tracker](https://diablo2.io/dclonetracker.php) progress changes and upcoming planned walks for Diablo 2: Resurrected. By default it will report any progress changes at or above level 2 for All Regions, Ladder and Non-Ladder, Softcore and planned walks an hour before they start.
 
-You can also get the current progress for tracked regions by typing `.dclone` or `!dclone` in chat.
+You can also get the current progress for tracked regions and upcoming walk information by typing `.dclone` or `!dclone` in chat.
 
 ## Usage
 
@@ -39,4 +39,4 @@ Start the bot with `python3 dclone-discord.py`.
 
 ## Disclaimer
 
-Data courtesy of [diablo2.io](https://diablo2.io/dclonetracker.php). Find more information about the API backing this project [here](https://diablo2.io/forums/diablo-clone-uber-diablo-tracker-public-api-t906872.html).
+Data courtesy of [diablo2.io](https://diablo2.io/dclonetracker.php) and [d2runewizard.com](https://d2runewizard.com/diablo-clone-tracker).

--- a/dclone-discord.py
+++ b/dclone-discord.py
@@ -134,6 +134,7 @@ class Diablo2IOClient():
         }
 
         # tracks planned walks from D2RuneWizard that have already alerted
+        # TODO: move to D2RuneWizardClient
         self.alerted_walks = []
 
     @staticmethod
@@ -215,6 +216,7 @@ class Diablo2IOClient():
         message += '> Data courtesy of diablo2.io'
 
         # get planned walks from d2runewizard.com API
+        # TODO: move to D2RuneWizardClient
         try:
             response = get('https://d2runewizard.com/api/diablo-clone-progress/planned-walks', timeout=10)
             response.raise_for_status()

--- a/dclone-discord.py
+++ b/dclone-discord.py
@@ -228,7 +228,7 @@ class Diablo2IOClient():
                     timestamp = int(walk.get('timestamp') / 1000)
                     name = walk.get('displayName')
                     emoji = D2RuneWizardClient.emoji(region=region, ladder=ladder, hardcore=hardcore)
-                    unconfirmed = ' **[UNCONFIRMED]]**' if not walk.get('confirmed') else ''
+                    unconfirmed = ' **[UNCONFIRMED]**' if not walk.get('confirmed') else ''
 
                     # TODO: filter to configured mode
                     message += f' - {emoji} **{region} {LADDER_RW[ladder]} {HC_RW[hardcore]}** <t:{timestamp}:R> reported by `{name}`{unconfirmed}\n'
@@ -368,7 +368,7 @@ class DiscordClient(discord.Client):
                 walk_in_mins = int(int(timestamp - time()) / 60)
 
                 # For walks in the next hour, send an alert if we have not already sent one
-                if walk_in_mins <= 60 and id not in self.dclone.alerted_walks:
+                if walk_in_mins <= 60 and walk_id not in self.dclone.alerted_walks:
                     region = walk.get('region')
                     ladder = walk.get('ladder')
                     hardcore = walk.get('hardcore')
@@ -378,8 +378,8 @@ class DiscordClient(discord.Client):
 
                     # post to discord
                     print(f'[PlannedWalk] {region} {LADDER_RW[ladder]} {HC_RW[hardcore]} reported by {name} in {walk_in_mins}m {unconfirmed}')
-                    message = f':alarm_clock: Upcoming walk for {emoji} **{region} {LADDER_RW[ladder]} {HC_RW[hardcore]}** '
-                    message += f'reported by `{name}` starts at <t:{timestamp}:f>{unconfirmed}'
+                    message = f'{emoji} Upcoming walk for **{region} {LADDER_RW[ladder]} {HC_RW[hardcore]}** '
+                    message += f'starts at <t:{timestamp}:f> (reported by `{name}`){unconfirmed}'
                     message += '\n> Data courtesy of d2runewizard.com'
 
                     channel = self.get_channel(DISCORD_CHANNEL_ID)

--- a/dclone-discord.py
+++ b/dclone-discord.py
@@ -136,7 +136,8 @@ class Diablo2IOClient():
         # tracks planned walks from D2RuneWizard that have already alerted
         self.alerted_walks = []
 
-    def emoji(self, region='', ladder='', hardcore=''):
+    @staticmethod
+    def emoji(region='', ladder='', hardcore=''):
         """
         Returns a string of Discord emoji for a given game mode.
 
@@ -208,7 +209,7 @@ class Diablo2IOClient():
             hardcore = data.get('hc')
             progress = int(data.get('progress'))
             timestamped = int(data.get('timestamped'))
-            emoji = self.emoji(region=region, ladder=ladder, hardcore=hardcore)
+            emoji = Diablo2IOClient.emoji(region=region, ladder=ladder, hardcore=hardcore)
 
             message += f' - {emoji} **{REGION[region]} {LADDER[ladder]} {HC[hardcore]}** is `{progress}/6` <t:{timestamped}:R>\n'
         message += '> Data courtesy of diablo2.io'
@@ -314,7 +315,7 @@ class DiscordClient(discord.Client):
             hardcore = data.get('hc')
             progress = int(data.get('progress'))
             reporter_id = data.get('reporter_id')
-            emoji = self.dclone.emoji(region=region, ladder=ladder, hardcore=hardcore)
+            emoji = Diablo2IOClient.emoji(region=region, ladder=ladder, hardcore=hardcore)
 
             progress_was = self.dclone.current_progress.get((region, ladder, hardcore))
 

--- a/dclone-discord.py
+++ b/dclone-discord.py
@@ -1,5 +1,21 @@
 #!/usr/bin/env python3
-# Discord Bot for tracking DClone - https://github.com/Synse/discord-dclone
+"""
+A Discord Bot for tracking DClone spawns in Diablo 2: Resurrected - https://github.com/Synse/discord-dclone
+Copyright (C) 2022 @Synse
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
 from datetime import timedelta
 from os import environ
 from time import time

--- a/dclone-discord.py
+++ b/dclone-discord.py
@@ -45,7 +45,7 @@ DCLONE_REPORTS = int(environ.get('DCLONE_REPORTS', 3))  # number of matching rep
 ########################
 # End of configuration #
 ########################
-__version__ = '0.6'
+__version__ = '0.7'
 REGION = {'1': 'Americas', '2': 'Europe', '3': 'Asia', '': 'All Regions'}
 LADDER = {'1': 'Ladder', '2': 'Non-Ladder', '': 'Ladder and Non-Ladder'}
 LADDER_RW = {True: 'Ladder', False: 'Non-Ladder'}


### PR DESCRIPTION
This PR adds upcoming [planned walk](https://d2runewizard.com/diablo-clone-tracker#planned-walks) information courtesy of `d2runewizard.com`.

Planned walks are shown in the chatop output and reported to Discord 1 hour before the start time.