### PR TITLE
Support D2RuneWizard Token

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Configuration is done via environment variables, or you can edit the variables n
  - `DCLONE_DISCORD_TOKEN`: Token for connecting to Discord, create a bot account with the instructions [here](https://discordpy.readthedocs.io/en/stable/discord.html). Only the `Send Messages` permission is required.
  - `DCLONE_DISCORD_CHANNEL_ID`: The [channel id](https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID-) to send messages to.
 
+**Optional (but recommended)**
+- `DCLONE_D2RW_TOKEN`: Token for querying d2runewizard.com, it is required if you want planned walk information. Get one [here](https://d2runewizard.com/integration).
+
 **Optional**
  - `DCLONE_REGION`: `1` for Americas, `2` for Europe, `3` for Asia, blank **(Default)** for All Regions.
  - `DCLONE_LADDER`: `1` for Ladder, `2` for Non-Ladder, blank **(Default)** for both.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dclone-discord
 
-![](https://img.shields.io/badge/version-0.9-blue)
+![](https://img.shields.io/badge/version-0.10-blue)
 
 A Discord bot for reporting [DClone Tracker](https://diablo2.io/dclonetracker.php) progress changes and upcoming [planned walks](https://d2runewizard.com/diablo-clone-tracker#planned-walks) for Diablo 2: Resurrected. By default it will report any progress changes at or above level 2 for All Regions, Ladder and Non-Ladder, Softcore and planned walks an hour before they start.
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,8 @@ Configuration is done via environment variables, or you can edit the variables n
  - `DCLONE_DISCORD_TOKEN`: Token for connecting to Discord, create a bot account with the instructions [here](https://discordpy.readthedocs.io/en/stable/discord.html). Only the `Send Messages` permission is required.
  - `DCLONE_DISCORD_CHANNEL_ID`: The [channel id](https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID-) to send messages to.
 
-**Optional (but recommended)**
-- `DCLONE_D2RW_TOKEN`: Token for querying d2runewizard.com, it is required if you want planned walk information. Get one [here](https://d2runewizard.com/integration).
-
 **Optional**
+ - `DCLONE_D2RW_TOKEN` (**Highly Recommended**): Token for querying d2runewizard.com, required if you want planned walk information. Request one [here](https://d2runewizard.com/integration).
  - `DCLONE_REGION`: `1` for Americas, `2` for Europe, `3` for Asia, blank **(Default)** for All Regions.
  - `DCLONE_LADDER`: `1` for Ladder, `2` for Non-Ladder, blank **(Default)** for both.
  - `DCLONE_HC`: `1` for Harcore, `2` for Softcore **(Default)**, blank for both.

--- a/dclone_discord.py
+++ b/dclone_discord.py
@@ -254,7 +254,7 @@ class Diablo2IOClient():
         # TODO: move to D2RuneWizardClient
         if DCLONE_D2RW_TOKEN:
             try:
-                response = get('https://d2runewizard.com/api/diablo-clone-progress/planned-walks', timeout=10)
+                response = get(f'https://d2runewizard.com/api/diablo-clone-progress/planned-walks?token={DCLONE_D2RW_TOKEN}', timeout=10)
                 response.raise_for_status()
 
                 # filter planned walks to configured mode and add relevant ones to the message
@@ -417,7 +417,7 @@ class DiscordClient(discord.Client):
         # check for upcoming walks using the D2RuneWizard API
         if DCLONE_D2RW_TOKEN:
             try:
-                response = get('https://d2runewizard.com/api/diablo-clone-progress/planned-walks', timeout=10)
+                response = get(f'https://d2runewizard.com/api/diablo-clone-progress/planned-walks?token={DCLONE_D2RW_TOKEN}', timeout=10)
                 response.raise_for_status()
 
                 walks = D2RuneWizardClient.filter_walks(response.json().get('walks'))

--- a/dclone_discord.py
+++ b/dclone_discord.py
@@ -50,7 +50,7 @@ DCLONE_REPORTS = int(environ.get('DCLONE_REPORTS', 3))  # number of matching rep
 ########################
 # End of configuration #
 ########################
-__version__ = '0.9'
+__version__ = '0.10'
 REGION = {'1': 'Americas', '2': 'Europe', '3': 'Asia', '': 'All Regions'}
 LADDER = {'1': 'Ladder', '2': 'Non-Ladder', '': 'Ladder and Non-Ladder'}
 LADDER_RW = {True: 'Ladder', False: 'Non-Ladder'}

--- a/dclone_discord.py
+++ b/dclone_discord.py
@@ -313,6 +313,10 @@ class DiscordClient(discord.Client):
         self.dclone = Diablo2IOClient()
         print(f'Tracking DClone for {REGION[DCLONE_REGION]}, {LADDER[DCLONE_LADDER]}, {HC[DCLONE_HC]}')
 
+        # DCLONE_D2RW_TOKEN is required for planned walk notifications
+        if not DCLONE_D2RW_TOKEN:
+            print('WARNING: DCLONE_D2RW_TOKEN is not set, you will not receive planned walk notifications.')
+
     async def on_ready(self):
         """
         Runs when the bot is connected to Discord and ready to receive messages. This starts our background task.


### PR DESCRIPTION
Sometime after 2022-09-25 https://d2runewizard.com/diablo-clone-tracker started requiring an API token. This PR adds support for that token.

Running the bot without this token will default to only using diablo2.io for data which doesn't have any planned walk information.

Integration docs are at: https://d2runewizard.com/integration