### PR TITLE
Use latest `discord.py`

### DIFF
--- a/dclone_discord.py
+++ b/dclone_discord.py
@@ -59,7 +59,7 @@ DCLONE_REPORTS = int(environ.get('DCLONE_REPORTS', 3))  # number of matching rep
 ########################
 # End of configuration #
 ########################
-__version__ = '0.13'
+__version__ = '1.0.0'
 REGION = {'1': 'Americas', '2': 'Europe', '3': 'Asia', '': 'All Regions'}
 LADDER = {'1': 'Ladder', '2': 'Non-Ladder', '': 'Ladder and Non-Ladder'}
 LADDER_RW = {True: 'Ladder', False: 'Non-Ladder'}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-aiohttp==3.7.4
-discord.py==1.7.3
+discord.py==2.4.0


### PR DESCRIPTION
This PR updates to use the [latest `discord.py` package](https://pypi.org/project/discord.py/#history) (version 2.4.0) which resolves security concerns with `aiohttp==3.7.4`.

This also updates the version to **1.0.0**.